### PR TITLE
2023 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_program(LSB_RELEASE_EXEC lsb_release)
 find_package(TBB REQUIRED)
 
 include(${ROOT_USE_FILE})
-string(CONCAT CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -Wall -Wextra -Wpedantic -Werror")
+string(CONCAT CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} " -Wall -Wextra -Werror -Wno-error=deprecated-copy")
 #grabs the distribution
 execute_process(COMMAND ${LSB_RELEASE_EXEC} -is
   OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT

--- a/DataContainer/Hit.hh
+++ b/DataContainer/Hit.hh
@@ -2,8 +2,8 @@
 #define HIT_HH
 
 #include "Utils/SimpleGeom.hh"
-
 #include "Utils/Helper.h"
+#include <set>
 
 typedef std::pair<double,double> extent;
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Supernova Clustering and triggering code at DUNE.
 
 ## Installation
-To compile it, you need to make sure you have `ROOT` setup, have `cmake` and `boost`. <b>
+To compile it, you need to make sure you have `ROOT` setup, have `cmake` and `boost`. <br>
 On FNAL/CERN machines (change versions as they become updated):
 ```sh
 source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Supernova Clustering and triggering code at DUNE.
 
 ## Installation
-To compile it, you need to make sure you have ROOT setup, have `cmake` and `boost`.
+To compile it, you need to make sure you have `ROOT` setup, have `cmake` and `boost`. <b>
 On FNAL/CERN machines (change versions as they become updated):
 ```sh
 source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh

--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 Supernova Clustering and triggering code at DUNE.
 
 ## Installation
-To compile it, you need to make sure you have a ROOT setup (`source <wherever root is>/bin/thisroot.sh`), have `cmake` and `boost`.
-I usually setup a developer version of `dunetpc` and that gives me everything I need on the fnal machines.
+To compile it, you need to make sure you have ROOT setup, have `cmake` and `boost`.
+On FNAL/CERN machines (change versions as they become updated):
+```sh
+source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
+setup dunesw v09_65_03d00 -q e20:prof
+setup cmake v3_24_1
+```
+
+Then, one can clone and build the repository:
 ```sh
 git clone <whatever the address of this is>
 cd <wherever you want to build>


### PR DESCRIPTION
This brings the clustering software 'up-to-date' so it (actually) builds in 2023 :)
Also updated the README to show the environment set-up needed.

Changes:
- Added `#include <set>` to DataContainer/Cluster.hh
- Added `-Wno-error=deprecated-copy` to CMakeLists.txt to allow some deprecated C++ expressions with new cmake
- Removed `-Wpedantic` from CMakeLists.txt to allow building with new root (>6), where some versions have a bug